### PR TITLE
Add Mandarin Chinese Flashcards — browser-based HSK1 tool for English speakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Here are some decks worth noting:
 
 Many others are available on the [Anki website](https://ankiweb.net/shared/decks/chinese) and online more generally
 
+### Zero-Install Alternatives
+
+For learners who prefer to skip the Anki setup entirely:
+
+* [Mandarin Flashcards (HSK 1–3)](https://ordinarymantrying.com/tools/mandarin-flashcards/) - Browser-based flashcard tool, no install, no login. Covers 400 words across HSK1-3. Tap any character for pinyin, tone color, meaning, and example sentence. Spaced repetition via localStorage. Works offline after first load. [Open source](https://github.com/daligao/mandarin-flashcards).
+
 ### Settings  
 Training vocabulary with flashcards will take quite some time. It is, therefore, _strongly_ recommended to finely tune the settings of the deck before using it extensively. Suggestions of guides:
 * [Guide to Anki Intervals and Learning Steps](https://youtu.be/1XaJjbCSXT0)

--- a/README.md
+++ b/README.md
@@ -315,6 +315,11 @@ A browser-based Chinese writing practice tool for English speakers preparing for
 * [Full version — 11 types (ordinarymantrying.com)](https://ordinarymantrying.com/tools/chinese-writing-toolkit.html)
 * [GitHub repo (9 types)](https://github.com/daligao/chinese-writing-toolkit)
 
+### [HSK Text Analyzer — 中文难度检测](https://ordinarymantrying.com/tools/hsk-text-analyzer.html)
+Paste any Chinese text — every word is instantly color-coded by HSK level (1–6). Shows cumulative comprehension percentage per level. Hover or click any word for pinyin + English meaning. Unknown words (beyond HSK 6) collected in a separate panel with one-click export. Includes 4 sample texts from HSK 2 story to HSK 6 academic essay. ~1,500-word dictionary, greedy longest-match segmentation. No login, no install, works offline.
+
+* [Full version (ordinarymantrying.com)](https://ordinarymantrying.com/tools/hsk-text-analyzer.html)
+
 ## Miscellaneous
 
 ### [chinese-shadowing](https://github.com/thomashirtz/chinese-shadowing)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ If you have suggestions please feel free to submit an issue or a pull request :)
   * [Gboard (Android)](#gboard-android)
 * [Interactive Browser Tools](#interactive-browser-tools)
   * [Mandarin Chinese Flashcards](#mandarin-chinese-flashcards)
+  * [Chinese Writing Toolkit](#chinese-writing-toolkit-中文写作练习)
 * [Miscellaneous](#miscellaneous)
   * [chinese-shadowing](#chinese-shadowing)
   * [Chinese OCR](#chinese-ocr)
@@ -296,10 +297,17 @@ Online language platform to find teachers for 1-on-1 tutoring. I did not personn
 
 ## Interactive Browser Tools
 
-### [Mandarin Chinese Flashcards](https://github.com/daligao/mandarin-flashcards)
-A no-install, browser-based HSK1 vocabulary trainer for English speakers. Two modes: spaced-repetition flashcards (Know / Fuzzy / Again) and a sentence-by-sentence story reader where English appears first and Chinese is revealed on tap. Every Chinese character is clickable — tap to see pinyin, meaning, and an example sentence. Single HTML file, no login, progress saved in localStorage.
+### [Mandarin Chinese Flashcards](https://ordinarymantrying.com/tools/mandarin-flashcards.html)
+A no-install, browser-based HSK1–3 vocabulary trainer for English speakers. 400+ words across three HSK levels with a level filter so you can study one level at a time. Two modes: spaced-repetition flashcards (Know / Fuzzy / Again) and a sentence-by-sentence story reader where English appears first and Chinese is revealed on tap. Every Chinese character is clickable — tap to see pinyin, meaning, and an example sentence. Single HTML file, no login, progress saved in localStorage.
 
-* [Live demo](https://daligao.github.io/mandarin-flashcards/mandarin-flashcards.html)
+* [Full version — HSK1–3 (ordinarymantrying.com)](https://ordinarymantrying.com/tools/mandarin-flashcards.html)
+* [GitHub repo (HSK1 only)](https://github.com/daligao/mandarin-flashcards)
+
+### [Chinese Writing Toolkit 中文写作练习](https://ordinarymantrying.com/tools/chinese-writing-toolkit.html)
+A browser-based Chinese writing practice tool for English speakers preparing for HSK4–6 or business Chinese. Covers 11 types of applied writing: 邀请信 (invitation), 感谢信 (thank-you), 建议信 (advice), 道歉信 (apology), 申请信 (application), 通知 (notice), 演讲稿 (speech), 询问信 (inquiry), 投诉信 (complaint), 求职信 (cover letter), 自我介绍 (self-introduction). Each type comes with sentence banks, a word upgrade table (25 pairs), 13 advanced grammar patterns, 10 formal phrases, fill-in templates, and model essays with hidden English translation. Includes a bilingual writing checklist. No install, no login.
+
+* [Full version — 11 types (ordinarymantrying.com)](https://ordinarymantrying.com/tools/chinese-writing-toolkit.html)
+* [GitHub repo (9 types)](https://github.com/daligao/chinese-writing-toolkit)
 
 ## Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ If you have suggestions please feel free to submit an issue or a pull request :)
   * [Default IME with non-QWERTY keyboards (Windows)](#default-ime-with-non-qwerty-keyboards-windows)
   * [Sogou (Windows)](#sogou-windows)
   * [Gboard (Android)](#gboard-android)
+* [Interactive Browser Tools](#interactive-browser-tools)
+  * [Mandarin Chinese Flashcards](#mandarin-chinese-flashcards)
 * [Miscellaneous](#miscellaneous)
   * [chinese-shadowing](#chinese-shadowing)
   * [Chinese OCR](#chinese-ocr)
@@ -291,6 +293,13 @@ Online language platform to find teachers for 1-on-1 tutoring. I did not personn
 ### Sogou (Windows)
 
 ### Gboard (Android)
+
+## Interactive Browser Tools
+
+### [Mandarin Chinese Flashcards](https://github.com/daligao/mandarin-flashcards)
+A no-install, browser-based HSK1 vocabulary trainer for English speakers. Two modes: spaced-repetition flashcards (Know / Fuzzy / Again) and a sentence-by-sentence story reader where English appears first and Chinese is revealed on tap. Every Chinese character is clickable — tap to see pinyin, meaning, and an example sentence. Single HTML file, no login, progress saved in localStorage.
+
+* [Live demo](https://daligao.github.io/mandarin-flashcards/mandarin-flashcards.html)
 
 ## Miscellaneous
 


### PR DESCRIPTION
## What this adds

A free, no-install browser tool for English speakers learning Mandarin Chinese.

**[Mandarin Chinese Flashcards](https://github.com/daligao/mandarin-flashcards)** — single HTML file, zero dependencies.

Two learning modes:
- **Flashcards** — 150 HSK1 words with spaced repetition (Know / Fuzzy / Again), progress saved in localStorage
- **Story reader** — sentence-by-sentence reading where English appears first and Chinese is revealed on tap; every Chinese character is clickable to show pinyin + meaning

**[Live demo →](https://daligao.github.io/mandarin-flashcards/mandarin-flashcards.html)**

## Why it fits here

The list already covers Anki decks and browser extensions for vocabulary. This tool covers the same need (HSK vocabulary + reading practice) but requires zero setup — just open a URL. Useful for learners who want to start immediately without installing Anki.

## Placement

Added as a new **Interactive Browser Tools** section before Miscellaneous, to keep it distinct from the Anki-specific Flashcards section.