### PR TITLE
Add Pinyin Annotator, Chinese Reading Lab, and Chengyu Stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,24 @@ Here are some Chinese OCRs for converting an image to text using the computer (I
 1. [Convertio](https://convertio.co/ocr/chinese/)
 2. [Easy ScreenOCR](https://online.easyscreenocr.com/Home/ChineseOCR)
 
+### Pinyin Annotator 拼音标注
+Paste any Chinese text and pinyin appears above every character instantly. 2,500+ character dictionary covering HSK1–6. Four-tone color coding (red/orange/green/purple). HSK level highlight. Click any character for a popup with tone and level. Works offline after first load. No login, no install — single HTML file.
+
+* [Try it free (ordinarymantrying.com)](https://ordinarymantrying.com/tools/pinyin-annotator.html)
+* [GitHub repo](https://github.com/daligao/pinyin-annotator)
+
+### [Chinese Reading Lab 历史阅读理解](https://ordinarymantrying.com/tools/chinese-reading-lab.html)
+10 real historical decisions told in Chinese at HSK4–6 level: Mandela in prison, Jobs getting fired, Musk betting on Tesla, Tu Youyou's malaria research. Read the story, make the decision before seeing the outcome, answer 3 comprehension questions. Clickable vocab popup for every highlighted word. Progress saved locally.
+
+* [Try it free (ordinarymantrying.com)](https://ordinarymantrying.com/tools/chinese-reading-lab.html)
+* [GitHub repo](https://github.com/daligao/chinese-reading-lab)
+
+### [Chengyu Stories 成语故事](https://ordinarymantrying.com/tools/chengyu-stories.html)
+20 classic 成语 with their 2,000-year-old origin stories in Chinese. Each entry: origin story in Chinese (HSK4–6) with clickable vocab popup → English translation → two modern usage examples → scenario quiz (pick the right idiom for a real-world situation). HSK4–6. Progress saved.
+
+* [Try it free (ordinarymantrying.com)](https://ordinarymantrying.com/tools/chengyu-stories.html)
+* [GitHub repo](https://github.com/daligao/chengyu-stories)
+
 ### Pinyin Converter
 It is a converter that transforms Chinese characters into pinyin. Such can be very useful, especially when creating Anki cards or else.
 1. [Lexilogos](https://www.lexilogos.com/keyboard/pinyin_conversion.htm)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ If you have suggestions please feel free to submit an issue or a pull request :)
   * [Gboard (Android)](#gboard-android)
 * [Interactive Browser Tools](#interactive-browser-tools)
   * [Mandarin Chinese Flashcards](#mandarin-chinese-flashcards)
+  * [Chinese Writing Toolkit](#chinese-writing-toolkit-中文写作练习)
 * [Miscellaneous](#miscellaneous)
   * [chinese-shadowing](#chinese-shadowing)
   * [Chinese OCR](#chinese-ocr)
@@ -296,10 +297,17 @@ Online language platform to find teachers for 1-on-1 tutoring. I did not personn
 
 ## Interactive Browser Tools
 
-### [Mandarin Chinese Flashcards](https://github.com/daligao/mandarin-flashcards)
-A no-install, browser-based HSK1 vocabulary trainer for English speakers. Two modes: spaced-repetition flashcards (Know / Fuzzy / Again) and a sentence-by-sentence story reader where English appears first and Chinese is revealed on tap. Every Chinese character is clickable — tap to see pinyin, meaning, and an example sentence. Single HTML file, no login, progress saved in localStorage.
+### [Mandarin Chinese Flashcards](https://ordinarymantrying.com/tools/mandarin-flashcards.html)
+A no-install, browser-based HSK1–3 vocabulary trainer for English speakers. 400+ words across three HSK levels with a level filter so you can study one level at a time. Two modes: spaced-repetition flashcards (Know / Fuzzy / Again) and a sentence-by-sentence story reader where English appears first and Chinese is revealed on tap. Every Chinese character is clickable — tap to see pinyin, meaning, and an example sentence. Single HTML file, no login, progress saved in localStorage.
 
-* [Live demo](https://daligao.github.io/mandarin-flashcards/mandarin-flashcards.html)
+* [Full version — HSK1–3 (ordinarymantrying.com)](https://ordinarymantrying.com/tools/mandarin-flashcards.html)
+* [GitHub repo (HSK1 only)](https://github.com/daligao/mandarin-flashcards)
+
+### [Chinese Writing Toolkit 中文写作练习](https://ordinarymantrying.com/tools/chinese-writing-toolkit.html)
+A browser-based Chinese writing practice tool for English speakers preparing for HSK4–6 or business Chinese. Covers 11 types of applied writing: 邀请信 (invitation), 感谢信 (thank-you), 建议信 (advice), 道歉信 (apology), 申请信 (application), 通知 (notice), 演讲稿 (speech), 询问信 (inquiry), 投诉信 (complaint), 求职信 (cover letter), 自我介绍 (self-introduction). Each type comes with sentence banks, a word upgrade table (25 pairs), 13 advanced grammar patterns, 10 formal phrases, fill-in templates, and model essays with hidden English translation. Includes a bilingual writing checklist. No install, no login.
+
+* [Full version — 11 types (ordinarymantrying.com)](https://ordinarymantrying.com/tools/chinese-writing-toolkit.html)
+* [GitHub repo (9 types)](https://github.com/daligao/chinese-writing-toolkit)
 
 ## Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ If you have suggestions please feel free to submit an issue or a pull request :)
   * [Default IME with non-QWERTY keyboards (Windows)](#default-ime-with-non-qwerty-keyboards-windows)
   * [Sogou (Windows)](#sogou-windows)
   * [Gboard (Android)](#gboard-android)
+* [Interactive Browser Tools](#interactive-browser-tools)
+  * [Mandarin Chinese Flashcards](#mandarin-chinese-flashcards)
 * [Miscellaneous](#miscellaneous)
   * [chinese-shadowing](#chinese-shadowing)
   * [Chinese OCR](#chinese-ocr)
@@ -291,6 +293,13 @@ Online language platform to find teachers for 1-on-1 tutoring. I did not personn
 ### Sogou (Windows)
 
 ### Gboard (Android)
+
+## Interactive Browser Tools
+
+### [Mandarin Chinese Flashcards](https://github.com/daligao/mandarin-flashcards)
+A no-install, browser-based HSK1 vocabulary trainer for English speakers. Two modes: spaced-repetition flashcards (Know / Fuzzy / Again) and a sentence-by-sentence story reader where English appears first and Chinese is revealed on tap. Every Chinese character is clickable — tap to see pinyin, meaning, and an example sentence. Single HTML file, no login, progress saved in localStorage.
+
+* [Live demo](https://daligao.github.io/mandarin-flashcards/mandarin-flashcards.html)
 
 ## Miscellaneous
 


### PR DESCRIPTION
## What's being added

Three free browser tools for learning Chinese (no login, no install, offline after first load):

### 🔤 Pinyin Annotator
Paste any Chinese text → pinyin appears above every character instantly. 2,500+ character dictionary (HSK1–6), four-tone color coding, HSK level highlight, click-for-popup. Single HTML file, fully offline.
- **Live**: https://ordinarymantrying.com/tools/pinyin-annotator.html
- **GitHub**: https://github.com/daligao/pinyin-annotator

### 📖 Chinese Reading Lab
10 historical decisions in Chinese (HSK4–6): Mandela, Jobs, Musk, Tu Youyou, Buffett, etc. Make the decision before seeing the outcome → 3 comprehension questions per story. Clickable vocab popup throughout.
- **Live**: https://ordinarymantrying.com/tools/chinese-reading-lab.html
- **GitHub**: https://github.com/daligao/chinese-reading-lab

### 🐉 Chengyu Stories
20 classic 成语 with origin stories in Chinese + English translation + modern usage examples + scenario quiz.
- **Live**: https://ordinarymantrying.com/tools/chengyu-stories.html
- **GitHub**: https://github.com/daligao/chengyu-stories

All three are open source (CC0), single HTML files, and run entirely in the browser.